### PR TITLE
ビルドコンテキストのメタデータをローカライズに含められるようにする

### DIFF
--- a/sample/app/package.hoshi
+++ b/sample/app/package.hoshi
@@ -3,4 +3,5 @@ metadata:
   availableTranslations:
     - en
     - ja
+  contextPrefix: hoshi_localize_meta_
 

--- a/src/cli/src/container.ts
+++ b/src/cli/src/container.ts
@@ -1,11 +1,12 @@
 import { PublishUseCase } from './usecases';
 import {
+  ContextRepository,
   PackagesRepository,
   ProjectsRepository,
   PublishRepository,
   VersionsRepository,
 } from '../../engine/src/repositories';
-import { ConverterDatastore, FilesDatastore } from '../../engine/src/datastore';
+import { ConverterDatastore, FilesDatastore, VariablesDatastore } from '../../engine/src/datastore';
 import { AndroidXmlConverter, AppleStringsConverter } from '../../engine/src/converters';
 
 type CliModulesContainer = {
@@ -15,14 +16,22 @@ type CliModulesContainer = {
 const createModulesContainer = (): CliModulesContainer => {
   const filesDatastore = new FilesDatastore();
   const converterDatastore = new ConverterDatastore([new AppleStringsConverter(), new AndroidXmlConverter()]);
+  const variablesDatastore = new VariablesDatastore();
 
   const projectsRepository = new ProjectsRepository(filesDatastore);
   const packagesRepository = new PackagesRepository(filesDatastore);
   const versionsRepository = new VersionsRepository(filesDatastore);
   const publishRepository = new PublishRepository(converterDatastore);
+  const contextRepository = new ContextRepository(variablesDatastore);
 
   return {
-    publish: new PublishUseCase(projectsRepository, packagesRepository, versionsRepository, publishRepository),
+    publish: new PublishUseCase(
+      projectsRepository,
+      packagesRepository,
+      versionsRepository,
+      publishRepository,
+      contextRepository,
+    ),
   };
 };
 

--- a/src/cli/src/usecases/publish.ts
+++ b/src/cli/src/usecases/publish.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { PublishParameter } from '../models';
 import {
+  ContextRepository,
   PackagesRepository,
   ProjectsRepository,
   PublishRepository,
@@ -57,16 +58,20 @@ class PublishUseCase {
 
   private publishRepository: PublishRepository;
 
+  private contextRepository: ContextRepository;
+
   public constructor(
     projectsRepository: ProjectsRepository,
     packagesRepository: PackagesRepository,
     versionsRepository: VersionsRepository,
     publishRepository: PublishRepository,
+    contextRepository: ContextRepository,
   ) {
     this.projectsRepository = projectsRepository;
     this.packagesRepository = packagesRepository;
     this.versionsRepository = versionsRepository;
     this.publishRepository = publishRepository;
+    this.contextRepository = contextRepository;
   }
 
   async processPublishAsync(parameter: PublishParameter): Promise<boolean> {
@@ -91,6 +96,9 @@ class PublishUseCase {
       console.error('Package not found');
       return false;
     }
+
+    // コンテキスト読み込み
+    const context = await this.contextRepository.fetchContextAsync(projectPath);
 
     const availableFormats = await this.publishRepository.availableFormatsAsync();
 
@@ -133,6 +141,7 @@ class PublishUseCase {
                 editableVersion,
                 pkg.metadata,
                 project.metadata,
+                context,
                 packageOutDir,
               ),
             ),

--- a/src/engine/src/converters/androidXml.ts
+++ b/src/engine/src/converters/androidXml.ts
@@ -35,11 +35,20 @@ class AndroidXmlConverter implements Converter {
   async exportAsync(param: ExportParameter): Promise<void> {
     const baseDir = path.join(param.outDir, 'axml');
     await createDirIfNotExistAsync(baseDir);
+    const contextPrefix = param.metadata.package.contextPrefix || param.metadata.project.contextPrefix || '';
+    const contextKeys = contextPrefix ? Object.keys(param.metadata.context) : [];
     await serialPromises(
       param.languages.map(async (lang) => {
         const buffer = `<?xml version="1.0" encoding="utf-8"?>
 <resources>
+${contextKeys
+  .map(
+    (key) =>
+      `    <string name="${keyEscape(contextPrefix + key)}">${valueEscape(param.metadata.context[key])}</string>`,
+  )
+  .join('\n')}
 ${param.keys
+  .filter((key) => !contextPrefix || !key.startsWith(contextPrefix))
   .sort()
   .map((key) =>
     isDeletedPhrase(param.phrases[key])

--- a/src/engine/src/datastore/index.ts
+++ b/src/engine/src/datastore/index.ts
@@ -1,4 +1,5 @@
 import FilesDatastore from './files';
 import ConverterDatastore from './converter';
+import VariablesDatastore from './variables';
 
-export { FilesDatastore, ConverterDatastore };
+export { FilesDatastore, ConverterDatastore, VariablesDatastore };

--- a/src/engine/src/datastore/variables.ts
+++ b/src/engine/src/datastore/variables.ts
@@ -1,0 +1,70 @@
+import * as util from 'util';
+import * as childProcess from 'child_process';
+
+const exec = util.promisify(childProcess.exec);
+
+const PREFIX = 'HOSHI_META_';
+
+class VariablesDatastore {
+  // eslint-disable-next-line class-methods-use-this
+  public getVariables(): Record<string, string> {
+    return Object.keys(process.env)
+      .filter((v) => v.startsWith('HOSHI_META_'))
+      .reduce(
+        (acc, rawKey) => {
+          const k = rawKey.substring(PREFIX.length).toLowerCase();
+          acc[k] = process.env[rawKey] as string;
+          return acc;
+        },
+        {} as Record<string, string>,
+      );
+  }
+
+  public async getGitVariablesAsync(baseDir: string): Promise<Record<string, string>> {
+    const commitSha = process.env.GITHUB_SHA || (await this.readGitHeadAsync(baseDir));
+    if (!commitSha) {
+      return {};
+    }
+    const commitDate = await this.readGitDateAsync(baseDir, commitSha);
+    if (!commitDate) {
+      return {};
+    }
+    return {
+      // eslint-disable-next-line prettier/prettier
+      commit_sha: commitSha,
+      // eslint-disable-next-line prettier/prettier
+      commit_date: new Date(commitDate * 1000).toISOString(),
+      // eslint-disable-next-line prettier/prettier
+      commit_date_timestamp: commitDate.toString(),
+    };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private async readGitHeadAsync(baseDir: string): Promise<string | null> {
+    try {
+      const result = await exec('git log -n 1 --format=%H', { encoding: 'utf8', cwd: baseDir });
+      return result.stdout ? result.stdout : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private async readGitDateAsync(baseDir: string, commitSha: string): Promise<number | null> {
+    try {
+      const result = await exec(`git log -1 --format=%cd --date=unix ${commitSha}`, { encoding: 'utf8', cwd: baseDir });
+      if (!result.stdout) {
+        return null;
+      }
+      const ts = parseInt(result.stdout, 10);
+      if (Number.isNaN(ts)) {
+        return null;
+      }
+      return ts;
+    } catch (e) {
+      return null;
+    }
+  }
+}
+
+export default VariablesDatastore;

--- a/src/engine/src/repositories/context.ts
+++ b/src/engine/src/repositories/context.ts
@@ -1,0 +1,20 @@
+import VariablesDatastore from '../datastore/variables';
+
+class ContextRepository {
+  private variablesDatastore: VariablesDatastore;
+
+  public constructor(variablesDatastore: VariablesDatastore) {
+    this.variablesDatastore = variablesDatastore;
+  }
+
+  public async fetchContextAsync(projectPath: string): Promise<Record<string, string>> {
+    const gitVariables = await this.variablesDatastore.getGitVariablesAsync(projectPath);
+    const envVariables = this.variablesDatastore.getVariables();
+    return {
+      ...gitVariables,
+      ...envVariables,
+    };
+  }
+}
+
+export default ContextRepository;

--- a/src/engine/src/repositories/index.ts
+++ b/src/engine/src/repositories/index.ts
@@ -2,5 +2,6 @@ import ProjectsRepository from './projects';
 import PackagesRepository from './packages';
 import VersionsRepository from './versions';
 import PublishRepository from './publish';
+import ContextRepository from './context';
 
-export { ProjectsRepository, PackagesRepository, VersionsRepository, PublishRepository };
+export { ProjectsRepository, PackagesRepository, VersionsRepository, PublishRepository, ContextRepository };

--- a/src/engine/src/repositories/publish.ts
+++ b/src/engine/src/repositories/publish.ts
@@ -17,6 +17,7 @@ class PublishRepository {
     data: EditableVersion,
     packageMetadata: Record<string, string>,
     projectMetadata: Record<string, string>,
+    context: Record<string, string>,
     outDir: string,
   ): Promise<boolean> {
     try {
@@ -27,6 +28,7 @@ class PublishRepository {
           project: projectMetadata,
           package: packageMetadata,
           version: data.metadata,
+          context,
         },
         languages: data.languages,
         keys: data.keys,

--- a/src/models/converter.ts
+++ b/src/models/converter.ts
@@ -7,6 +7,7 @@ export type ExportParameter = {
     project: Record<string, string>;
     package: Record<string, string>;
     version: Record<string, string>;
+    context: Record<string, string>;
   };
   languages: string[];
   keys: string[];


### PR DESCRIPTION
## 概要

- 文言ファイルの出力に使ったgit commitなどを把握したい
- デバッグ画面等から出力を確認できるようにもしたい
- 文言に特定のプレフィクスで定義された文言を入れられるようにする

## 仕様

- project / package のコンテキストでメタデータに `contextPrefix` という文字列を追加できるようにする
- contextPrefix が出力されている場合は、以下のキーの文言をファイルに付与する
    - `${contextPrefix}commit_sha`: git の commit sha
    - `${contextPrefix}commit_date`: git commit の日時
    - `${contextPrefix}commit_date_timestamp`: git commit の日時(unix timestamp)
    - `${contextPrefix}${var}`: 環境変数 `HOSHI_META_${var}` の値 (キーは小文字になる)
        - ex: `HOSHI_META_COMMITER_NAME` なら `${contextPrefix}committer_name` が作成される
- contextPrefix が指定されている場合、実文言のうち contextPrefix から始まるものは出力されなくなる
    - 各プロジェクトの決め事として、禁止プレフィクスを決定する
