### PR TITLE
YAMLParseErrorを受け取ったときはそのままエラーとして投げるように変更

### DIFF
--- a/src/engine/src/datastore/files.ts
+++ b/src/engine/src/datastore/files.ts
@@ -11,6 +11,7 @@ import ProjectFile from '../projectFile';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { PackageFileName } from '../../../models/file';
+import { YAMLParseError } from 'yaml';
 
 class FilesDatastore {
   private projectFile: ProjectFile | undefined;
@@ -106,8 +107,11 @@ class FilesDatastore {
         historyPhrases,
         phrases,
       };
-    } catch (e) {
+    } catch (e: unknown) {
       // console.error(e);
+      if (e instanceof YAMLParseError) {
+        throw(e)
+      }
       return undefined;
     }
   }


### PR DESCRIPTION
resolve #3 

## Changed

- addNewPackageAsyncでYAMLParseErrorを受け取ったときに、undefinedの代わりに YAMLParseErrorをそのままthrowするようにし、YAMLのパースエラーであることをわかりやすくしました。

## Evidence

### Before

```shell
h1d3mun3@h1d3mun3s-Laptop hoshi % npm run cli -- publish --project sample --outDir _published app

> hoshi@0.3.0 cli
> ts-node --project tsconfig.cli.json src/cli/src/index.ts publish --project sample --outDir _published app

Error: Package app: load failed
    at /Users/h1d3mun3/GitHub/hoshi/src/cli/src/usecases/publish.ts:124:19
    at async serialPromises (/Users/h1d3mun3/GitHub/hoshi/src/engine/src/helpers.ts:6:5)
    at async PublishUseCase.processPublishAsync (/Users/h1d3mun3/GitHub/hoshi/src/cli/src/usecases/publish.ts:98:7)
    at async handlePublish (/Users/h1d3mun3/GitHub/hoshi/src/cli/src/handlers/index.ts:7:3)
h1d3mun3@h1d3mun3s-Laptop hoshi % 
```

### After
```shell
h1d3mun3@h1d3mun3s-Laptop hoshi % npm run cli -- publish --project sample --outDir _published app

> hoshi@0.3.0 cli
> ts-node --project tsconfig.cli.json src/cli/src/index.ts publish --project sample --outDir _published app

YAMLParseError: Map keys must be unique at line 5, column 3:

    ja: こんばんは
  greeting_evening:
  ^

    at Composer.onError (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/composer.js:69:34)
    at Object.resolveBlockMap (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/resolve-block-map.js:61:13)
    at resolveCollection (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/compose-collection.js:13:27)
    at Object.composeCollection (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/compose-collection.js:47:16)
    at composeNode (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/compose-node.js:31:38)
    at Object.resolveBlockMap (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/resolve-block-map.js:81:19)
    at resolveCollection (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/compose-collection.js:13:27)
    at Object.composeCollection (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/compose-collection.js:47:16)
    at Object.composeNode (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/compose-node.js:31:38)
    at Object.composeDoc (/Users/h1d3mun3/GitHub/hoshi/node_modules/yaml/dist/compose/compose-doc.js:33:23) {
  code: 'DUPLICATE_KEY',
  pos: [ 67, 68 ],
  linePos: [ { line: 5, col: 3 }, { line: 5, col: 4 } ]
}
h1d3mun3@h1d3mun3s-Laptop hoshi % 
```