### PR TITLE
読み込みに失敗したファイルと理由がわかるようにする・終了コードがエラーになるようにする

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,6 +13,9 @@ module.exports = {
   ],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
+  settings: {
+    'import/core-modules': ['electron'],
+  },
   rules: {
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': ['error'],

--- a/src/cli/src/handlers/index.ts
+++ b/src/cli/src/handlers/index.ts
@@ -1,8 +1,9 @@
 import createModulesContainer from '../container';
 import { PublishParameter } from '../models';
+import { Result } from '../../../models';
 
 // eslint-disable-next-line import/prefer-default-export
-export const handlePublish = async (parameter: PublishParameter): Promise<void> => {
+export const handlePublish = async (parameter: PublishParameter): Promise<Result<void, string>> => {
   const container = createModulesContainer();
-  await container.publish.processPublishAsync(parameter);
+  return container.publish.processPublishAsync(parameter);
 };

--- a/src/cli/src/index.ts
+++ b/src/cli/src/index.ts
@@ -10,6 +10,15 @@ program
   .option('-v, --version <version>', 'publish translations at version')
   .option('-f, --format <format>', 'publish format')
   .option('-o, --outDir <dir>', 'output directory', '_published')
-  .action((packages, _, cmd) => handlePublish({ packages, options: cmd.optsWithGlobals() }).then());
+  .action(async (packages, _, cmd) => {
+    const result = await handlePublish({ packages, options: cmd.optsWithGlobals() });
+    if (result.status === 'error') {
+      program.error(result.error);
+    }
+  });
 
-program.parse();
+async function main(): Promise<void> {
+  await program.parseAsync(process.argv);
+}
+
+main().then();

--- a/src/cli/src/usecases/index.ts
+++ b/src/cli/src/usecases/index.ts
@@ -1,2 +1,4 @@
 import PublishUseCase from './publish';
+
+// eslint-disable-next-line import/prefer-default-export
 export { PublishUseCase };

--- a/src/cli/src/usecases/publish.ts
+++ b/src/cli/src/usecases/publish.ts
@@ -165,7 +165,11 @@ class PublishUseCase {
         }),
       );
     } catch (e) {
-      console.error(e);
+      if (e instanceof Error) {
+        console.error(e.message);
+      } else {
+        console.error(`unknown error ${e}`);
+      }
       return false;
     }
 

--- a/src/engine/src/datastore/files.ts
+++ b/src/engine/src/datastore/files.ts
@@ -12,9 +12,8 @@ import {
   errorResult,
   successResult,
 } from '../../../models';
-import ProjectFile from '../projectFile/projectFile';
 import { FileLoadError, PackageFileName } from '../../../models/file';
-import ProjectFileError from '../projectFile/projectFileError';
+import { ProjectFile, ProjectFileError } from '../projectFile';
 
 class FilesDatastore {
   private projectFile: ProjectFile | undefined;

--- a/src/engine/src/projectFile/index.ts
+++ b/src/engine/src/projectFile/index.ts
@@ -1,2 +1,2 @@
-export * from './projectFileError';
-export * from './projectFile';
+export { default as ProjectFileError } from './projectFileError';
+export { default as ProjectFile } from './projectFile';

--- a/src/engine/src/projectFile/index.ts
+++ b/src/engine/src/projectFile/index.ts
@@ -1,0 +1,2 @@
+export * from './projectFileError';
+export * from './projectFile';

--- a/src/engine/src/projectFile/projectFileError.ts
+++ b/src/engine/src/projectFile/projectFileError.ts
@@ -1,0 +1,13 @@
+class ProjectFileError extends Error {
+  public fileName?: string;
+
+  public positions: { line: number; column: number }[];
+
+  public constructor(message: string, fileName?: string, positions: { line: number; column: number }[] = []) {
+    super(message);
+    this.fileName = fileName;
+    this.positions = positions;
+  }
+}
+
+export default ProjectFileError;

--- a/src/engine/src/repositories/versions.ts
+++ b/src/engine/src/repositories/versions.ts
@@ -1,5 +1,6 @@
 import FilesDatastore from '../datastore/files';
-import { EditableVersion, Version } from '../../../models';
+import { EditableVersion, Result, Version } from '../../../models';
+import { FileLoadError } from '../../../models/file';
 
 class VersionsRepository {
   private filesDatastore: FilesDatastore;
@@ -12,7 +13,7 @@ class VersionsRepository {
     packageId: string,
     versionId: string,
     includeCurrentVersionInHistory: boolean = false,
-  ): Promise<EditableVersion | undefined> {
+  ): Promise<Result<EditableVersion, FileLoadError>> {
     return this.filesDatastore.fetchEditableVersionAsync(packageId, versionId, includeCurrentVersionInHistory);
   }
 

--- a/src/main/api/handler.ts
+++ b/src/main/api/handler.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { BrowserWindow, dialog } from 'electron';
 import { EditableVersion, HoshiAPI, SmalledPackage, SmalledProject, Version } from '../../models';
 import createModulesContainer from './container';
@@ -49,8 +50,12 @@ const createAPIHandler: (window: BrowserWindow) => APIHandler = (window) => {
       deleteVersionAsync(packageId: string, versionId: string): Promise<void> {
         return container.versions.deleteVersionAsync(packageId, versionId);
       },
-      fetchEditableVersionAsync(packageId: string, versionId: string): Promise<EditableVersion | undefined> {
-        return container.versions.fetchEditableVersionAsync(packageId, versionId);
+      fetchEditableVersionAsync: async (packageId: string, versionId: string): Promise<EditableVersion | undefined> => {
+        const result = await container.versions.fetchEditableVersionAsync(packageId, versionId);
+        if (result.status === 'success') {
+          return result.data;
+        }
+        return undefined;
       },
       updateVersionAsync(packageId: string, versionId: string, data: Version): Promise<void> {
         return container.versions.updateVersionAsync(packageId, versionId, data);

--- a/src/main/api/usecases/versions.ts
+++ b/src/main/api/usecases/versions.ts
@@ -1,5 +1,6 @@
 import { VersionsRepository } from '../../../engine/src/repositories';
-import { EditableVersion, Version } from '../../../models';
+import { EditableVersion, Result, Version } from '../../../models';
+import { FileLoadError } from '../../../models/file';
 
 class VersionsUseCase {
   private versionsRepository: VersionsRepository;
@@ -8,7 +9,7 @@ class VersionsUseCase {
     this.versionsRepository = versionsRepository;
   }
 
-  fetchEditableVersionAsync(packageId: string, versionId: string): Promise<EditableVersion | undefined> {
+  fetchEditableVersionAsync(packageId: string, versionId: string): Promise<Result<EditableVersion, FileLoadError>> {
     return this.versionsRepository.fetchEditableVersionAsync(packageId, versionId);
   }
 

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -11,3 +11,21 @@ export const PackageFileName = `package${AppFileExt}`;
 export type FileHeader = {
   type: string;
 };
+
+export type FileLoadError =
+  | {
+      type: 'parseError';
+      message: string;
+      file?: string;
+      positions: { line: number; column: number }[];
+    }
+  | {
+      type: 'noPackage';
+    }
+  | {
+      type: 'exception';
+      error: Error;
+    }
+  | {
+      type: 'unknown';
+    };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,3 @@
 export * from './project';
 export * from './api';
+export * from './result';

--- a/src/models/result.ts
+++ b/src/models/result.ts
@@ -1,0 +1,21 @@
+export type SuccessResult<T> = {
+  status: 'success';
+  data: T;
+};
+
+export type ErrorResult<T> = {
+  status: 'error';
+  error: T;
+};
+
+export type Result<T, E> = SuccessResult<T> | ErrorResult<E>;
+
+export const successResult = <T>(data: T): SuccessResult<T> => ({
+  status: 'success',
+  data,
+});
+
+export const errorResult = <T>(error: T): ErrorResult<T> => ({
+  status: 'error',
+  error,
+});


### PR DESCRIPTION
closes #3 

- 層間でエラー付きの値をやりとりするためのResult型を追加
- YAMLを読み込む処理の場合、ファイル名を上位層で取得できるよう独自例外の追加
- fetchEditableVersionAsync の戻り値を Result 型に変更
- エラー発生時はcliコマンドの終了コードが0にならないように処理を追加

## Evidence

```
$ npm run cli -- publish --project sample --outDir _published app

> hoshi@0.3.0 cli
> ts-node --project tsconfig.cli.json src/cli/src/index.ts publish --project sample --outDir _published app

Package app: app/0004000_reintroduce_morning.yaml Map keys must be unique at line 7, column 3:

    ja: おはようございます
  greeting_morning:
  ^

$ echo $?
1
```

```
$ npm run cli -- publish --project sample --outDir _published app

> hoshi@0.3.0 cli
> ts-node --project tsconfig.cli.json src/cli/src/index.ts publish --project sample --outDir _published app

$ echo $?
0
```