### PR TITLE
コンパイラが生成する*.d.tsを無視する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist
 out
 _published
 *.log*
+
+src/**/*.d.ts
+!src/renderer/src/env.d.ts
+!src/preload/index.d.ts


### PR DESCRIPTION
tsconfigのcomposite設定があるとビルド時に自動的に生成される。
利用上不要のため、ignoreしておく。