### PR TITLE
[i18next] %% でエスケープされているものを変換したときにエラーになる

### DIFF
--- a/src/engine/src/converters/i18next.test.ts
+++ b/src/engine/src/converters/i18next.test.ts
@@ -11,5 +11,6 @@ test('escape format string', () => {
   expect(valueEscape('%d %f')).toBe('{{v1}} {{v2}}');
   expect(valueEscape('%4d %.2f')).toBe('{{v1, minimumIntegerDigits: 4}} {{v2, minimumFractionDigits: 2}}');
   expect(valueEscape('%4.2f')).toBe('{{v1, minimumIntegerDigits: 4, minimumFractionDigits: 2}}');
+  expect(valueEscape('%s%%')).toBe('{{v1}}%');
   expect(() => valueEscape('%hogefuga')).toThrow();
 });

--- a/src/engine/src/converters/i18next.ts
+++ b/src/engine/src/converters/i18next.ts
@@ -22,8 +22,8 @@ export const valueEscape = (input: string | undefined): string => {
       break;
     }
     if (input.charAt(nextIndex + 1) === '%') {
-      output += input.substring(i, nextIndex + 1);
-      i = nextIndex;
+      output += '%';
+      i = nextIndex + 1;
     } else {
       // そこまでの文字列は確定
       output += input.substring(i, nextIndex);


### PR DESCRIPTION
%% でエスケープされている際の処理が不十分で変換したときにエラーになる問題を修正