### PR TITLE
fix do not fallback when translation is set to empty string or null

### DIFF
--- a/packages/core/src/converters/appleStrings.ts
+++ b/packages/core/src/converters/appleStrings.ts
@@ -48,7 +48,7 @@ class AppleStringsConverter implements Converter {
             }
             const phrase = param.phrases[key];
             let phraseText = phrase.translations[lang];
-            if (!phraseText && fallbackLanguage) {
+            if (phraseText === undefined && fallbackLanguage) {
               phraseText = phrase.translations[fallbackLanguage];
             }
             return `"${keyEscape(key)}" = "${valueEscape(phraseText)}";`;

--- a/packages/core/src/converters/json.ts
+++ b/packages/core/src/converters/json.ts
@@ -39,7 +39,7 @@ class JsonConverter implements Converter {
               }
               const phrase = param.phrases[key];
               let phraseText = phrase.translations[lang];
-              if (!phraseText && fallbackLanguage) {
+              if (phraseText === undefined && fallbackLanguage) {
                 phraseText = phrase.translations[fallbackLanguage];
               }
               return [keyEscape(key), valueEscape(phraseText)];

--- a/packages/core/src/converters/nextintl.ts
+++ b/packages/core/src/converters/nextintl.ts
@@ -139,7 +139,7 @@ class NextIntlConverter implements Converter {
               }
               const phrase = param.phrases[key];
               let phraseText = phrase.translations[lang];
-              if (!phraseText && fallbackLanguage) {
+              if (phraseText === undefined && fallbackLanguage) {
                 phraseText = phrase.translations[fallbackLanguage];
               }
               return [keyEscape(key), valueEscape(phraseText)];

--- a/packages/core/src/converters/typescript.ts
+++ b/packages/core/src/converters/typescript.ts
@@ -92,7 +92,7 @@ class TypeScriptConverter implements Converter {
               }
               const phrase = param.phrases[key];
               let phraseText = phrase.translations[lang];
-              if (!phraseText && fallbackLanguage) {
+              if (phraseText === undefined && fallbackLanguage) {
                 phraseText = phrase.translations[fallbackLanguage];
               }
               return [keyEscape(key), phraseText];

--- a/sample/app/0006000_fallback.yaml
+++ b/sample/app/0006000_fallback.yaml
@@ -3,3 +3,11 @@ phrases:
   fallback:
     $description: test for fallback not defined in ja
     en: "fallback english text"
+  not_fallback1:
+    $description: test for not fallback
+    en: "not fallback english text"
+    ja: ""
+  not_fallback2:
+    $description: test for not fallback
+    en: "not fallback english text"
+    ja: null


### PR DESCRIPTION
fix: #58 

phraseTextがundefinedの場合のみ、フォールバックする挙動となるように修正
テストコードは特にないのでsampleのYAMLにフォールバックしないケースも追加